### PR TITLE
Web ui cleanup/hacking

### DIFF
--- a/cftweb/cftweb/templates/asciiart.html
+++ b/cftweb/cftweb/templates/asciiart.html
@@ -1,8 +1,15 @@
 {% extends "base.jinja" %}
 {% block page_css %}
   <style>
-    .alnviz-col {
+    .col-container {
+      width: 100%;
+    }
+    .scrollable {
       overflow-x: scroll;
+    }
+    .resizable {
+      resize: horizontal;
+      float: left;
     }
     .ascii-art {
       /* float: right; */
@@ -23,20 +30,20 @@
 
 {% block content %}
 
-<div class="row">
-  <div class="alnviz-col col-md-6">
+<div class="col-container">
+  <div class="scrollable resizable" style="width: 35%;">
     <div class="ascii-art">
       {{asciiart|safe}}
     </div>
   </div>
-  <div class="alnviz-col col-md-1">
+  <div class="scrollable resizable" style="width: 10%;">
     <div>&nbsp;</div><div>&nbsp;</div>
     {% for rec in records %}
     <div class="ascii-art"> &gt; {{rec.id}} </div>
     {% endfor %}
     <div>&nbsp;</div>
   </div>
-  <div class="alnviz-col col-md-5">
+  <div class="scrollable" style="width: auto;">
     <div>&nbsp;</div><div>&nbsp;</div>
     {% for rec in records %}
     <div class="ascii-art"> {{rec.seq}} </div>


### PR DESCRIPTION
Accomplished the following:
* miscellaneous view cleanup for tree/alignment asciiart
* scrollable alignment/seqname columns
* resizable columns

Right now the resize only works via the bottom right corner of the column divs. Not sure if there's really a good way around with without resorting to JS. And probably fine for now. Would be nice to add a border that can dragged for resizing, similar to jsfiddle's panes (I think they use JS, but not sure).