### PR TITLE
svg-tree link/page and fit svg to container in main view; closes #87

### DIFF
--- a/cftweb/cftweb/templates/cluster.html
+++ b/cftweb/cftweb/templates/cluster.html
@@ -16,6 +16,12 @@
 	    white-space: pre;
 	    font-family: monospace;
     }
+    .svg-container {
+      width: 100%;
+    }
+
+
+    /* The alignment coloring/styling */
     span.Vgene {
       background-color: #b2d28e
     }
@@ -122,7 +128,7 @@
 
 <div class="row display-toggle" style="display: none;">
   <div class="col-md-12" style="overflow-x: scroll;">
-    <figure class="svg-container w80">
+    <figure class="svg-container w80" href="{{ url_for('svg_view', id=cluster.id) }}">
       {{ svg | safe }}
     </figure>
   </div>
@@ -151,12 +157,16 @@
 </div>
 
 <script type="text/javascript">
-console.log("hello from outside");
 $(function() {
-    console.log("Hello world");
     $(".view-mode-toggle").click(function() {
       console.log("Toggling view mode");
       $(".display-toggle").toggle();
+      });
+    $(".svg-container svg").width("100%").height("100%");
+    $(".svg-container").click(function() {
+      console.log("Opening svg in new tab");
+      var url = $(".svg-container").attr("href");
+      window.open(url);
       });
     });
 </script>

--- a/cftweb/cftweb/views.py
+++ b/cftweb/cftweb/views.py
@@ -178,3 +178,11 @@ def seedlineage_fasta(id=None):
     return flask.send_file(cluster.seedlineage)
 
 
+@app.route("/cluster/<id>/tree.svg")
+def svg_view(id=None):
+    clusters = app.config['CLUSTERS']
+    cluster = clusters[id]
+
+    return flask.send_file(cluster.svg)
+
+


### PR DESCRIPTION
I ended up figuring out a decent way of just fitting the svg to the parent container. This may be overall a better solution, so perhaps we'll drop the click to open in new tab thing, but for now we have both to play with.