### PR TITLE
update partis get-selection-metrics/get-tree-metrics call

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1046,8 +1046,8 @@ def add_cluster_analysis(w):
 
         tree_metrics = env.Command(
             [path.join(outdir, "selection-metrics.yaml")],
-            c["asr_tree"],  # sources
-            "%s/bin/get-tree-metrics.py ${SOURCES[0]} ${TARGETS[0]}" % (partis_path),
+            [c["partition"]["partition-file"], c["asr_tree"]],  # sources
+            "%s/bin/partis get-selection-metrics --outfname ${SOURCES[0]} --treefname ${SOURCES[1]} --selection-metric-fname ${TARGETS[0]}" % (partis_path),
         )
         env.Depends(tree_metrics, "partis/bin/get-tree-metrics.py")
         return tree_metrics


### PR DESCRIPTION
I'm not sure that this is precisely the partis command we want in the long term, since it will get selection metrics for all clusters that share any uids with the tree we're passing in. And, more importantly, this doesn't get any of the inferred intermediate sequences from cft's tree inference. But getting the latter will require adding a partis annotate call, so we can add it later.